### PR TITLE
Add NavigationService and it's required interfaces to enable simpler single-page navigation. Also added a simple NavigationService exception

### DIFF
--- a/AvaloniaNavigationFramework/AvaloniaNavigationFramework.csproj
+++ b/AvaloniaNavigationFramework/AvaloniaNavigationFramework.csproj
@@ -6,4 +6,10 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="11.1.3" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/AvaloniaNavigationFramework/Exceptions/NavigationServiceException.cs
+++ b/AvaloniaNavigationFramework/Exceptions/NavigationServiceException.cs
@@ -1,0 +1,8 @@
+﻿namespace NavTest.Exceptions
+{
+    public class NavigationServiceException : Exception
+    {
+        public NavigationServiceException(string message) : base(message) { }
+        public NavigationServiceException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/AvaloniaNavigationFramework/Services/INavigationAware.cs
+++ b/AvaloniaNavigationFramework/Services/INavigationAware.cs
@@ -1,0 +1,9 @@
+﻿namespace NavTest.Services
+{
+    public interface INavigationAware
+    {
+        Task OnNavigatedToAsync(object parameter);
+        Task OnNavigatedFromAsync();
+        Task<bool> CanNavigateAwayAsync();
+    }
+}

--- a/AvaloniaNavigationFramework/Services/INavigationService.cs
+++ b/AvaloniaNavigationFramework/Services/INavigationService.cs
@@ -1,0 +1,12 @@
+﻿using Avalonia.Controls;
+
+namespace NavTest.Services
+{
+    public interface INavigationService
+    {
+        Task NavigateAsync(Type viewModelType, CancellationToken cancellationToken = default);
+        Task NavigateAsync(Type viewModelType, object parameter, CancellationToken cancellationToken = default);
+        Task GoBackAsync(CancellationToken cancellationToken = default);
+        void Initialize(ContentControl contentControl, IServiceProvider serviceProvider);
+    }
+}

--- a/AvaloniaNavigationFramework/Services/NavigationService.cs
+++ b/AvaloniaNavigationFramework/Services/NavigationService.cs
@@ -1,0 +1,162 @@
+﻿using Avalonia.Controls;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.Extensions.DependencyInjection;
+using NavTest.Exceptions;
+
+namespace NavTest.Services
+{
+    public class NavigationService : ObservableObject, INavigationService
+    {
+        private readonly Dictionary<Type, Type> _viewModelToViewMappings = new Dictionary<Type, Type>();
+        private readonly Stack<NavigationItem> _navigationStack = new Stack<NavigationItem>();
+        private ContentControl _contentControl;
+        private IServiceProvider _serviceProvider;
+
+        private ObservableObject _currentViewModel;
+        public ObservableObject CurrentViewModel
+        {
+            get => _currentViewModel;
+            private set => SetProperty(ref _currentViewModel, value);
+        }
+
+        public void Initialize(ContentControl contentControl, IServiceProvider serviceProvider)
+        {
+            _contentControl = contentControl ?? throw new ArgumentNullException(nameof(contentControl));
+            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        }
+
+        public void RegisterView<TViewModel, TView>()
+            where TViewModel : ObservableObject
+            where TView : Control
+        {
+            if (_viewModelToViewMappings.ContainsKey(typeof(TViewModel)))
+            {
+                throw new NavigationServiceException($"A view is already registered for ViewModel type {typeof(TViewModel)}");
+            }
+
+            _viewModelToViewMappings[typeof(TViewModel)] = typeof(TView);
+        }
+
+        public Task NavigateAsync(Type viewModelType, CancellationToken cancellationToken = default)
+        {
+            return NavigateAsync(viewModelType, null, cancellationToken);
+        }
+
+        public async Task NavigateAsync(Type viewModelType, object parameter, CancellationToken cancellationToken = default)
+        {
+            EnsureInitialized();
+
+            if (!_viewModelToViewMappings.ContainsKey(viewModelType))
+            {
+                throw new NavigationServiceException($"No view registered for ViewModel type {viewModelType}");
+            }
+
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var viewModel = (ObservableObject)_serviceProvider.GetRequiredService(viewModelType);
+
+                if (CurrentViewModel is INavigationAware currentNavigationAware)
+                {
+                    if (!await currentNavigationAware.CanNavigateAwayAsync())
+                    {
+                        throw new NavigationCanceledException("Navigation was cancelled by the current view model.");
+                    }
+                    await currentNavigationAware.OnNavigatedFromAsync();
+                }
+
+                if (viewModel is INavigationAware navigationAware)
+                {
+                    await navigationAware.OnNavigatedToAsync(parameter);
+                }
+
+                var view = (Control)_serviceProvider.GetRequiredService(_viewModelToViewMappings[viewModelType]);
+                view.DataContext = viewModel;
+
+                _contentControl.Content = view;
+                _navigationStack.Push(new NavigationItem(viewModel, parameter));
+                CurrentViewModel = viewModel;
+            }
+            catch (OperationCanceledException)
+            {
+                throw new NavigationCanceledException("Navigation was cancelled.");
+            }
+            catch (Exception ex)
+            {
+                throw new NavigationServiceException($"Failed to navigate to {viewModelType}", ex);
+            }
+        }
+
+        public async Task GoBackAsync(CancellationToken cancellationToken = default)
+        {
+            EnsureInitialized();
+
+            if (_navigationStack.Count <= 1)
+            {
+                throw new NavigationServiceException("Cannot go back. This is the first page in the navigation stack.");
+            }
+
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (CurrentViewModel is INavigationAware currentNavigationAware)
+                {
+                    if (!await currentNavigationAware.CanNavigateAwayAsync())
+                    {
+                        throw new NavigationCanceledException("Navigation was cancelled by the current view model.");
+                    }
+                    await currentNavigationAware.OnNavigatedFromAsync();
+                }
+
+                _navigationStack.Pop();
+                var previousItem = _navigationStack.Peek();
+
+                if (previousItem.ViewModel is INavigationAware previousNavigationAware)
+                {
+                    await previousNavigationAware.OnNavigatedToAsync(previousItem.Parameter);
+                }
+
+                var view = (Control)_serviceProvider.GetRequiredService(_viewModelToViewMappings[previousItem.ViewModel.GetType()]);
+                view.DataContext = previousItem.ViewModel;
+
+                _contentControl.Content = view;
+                CurrentViewModel = previousItem.ViewModel;
+            }
+            catch (OperationCanceledException)
+            {
+                throw new NavigationCanceledException("Navigation was cancelled.");
+            }
+            catch (Exception ex)
+            {
+                throw new NavigationServiceException("Failed to navigate back", ex);
+            }
+        }
+
+        private void EnsureInitialized()
+        {
+            if (_contentControl == null || _serviceProvider == null)
+            {
+                throw new NavigationServiceException("NavigationService has not been properly initialized. Make sure Initialize method is called with a valid ContentControl and IServiceProvider.");
+            }
+        }
+
+        private class NavigationItem
+        {
+            public ObservableObject ViewModel { get; }
+            public object Parameter { get; }
+
+            public NavigationItem(ObservableObject viewModel, object parameter)
+            {
+                ViewModel = viewModel;
+                Parameter = parameter;
+            }
+        }
+    }
+
+    public class NavigationCanceledException : Exception
+    {
+        public NavigationCanceledException(string message) : base(message) { }
+    }
+}


### PR DESCRIPTION
First basic implementation of an async navigation service. It currently supports single-page navigation via swapping out the View or UserControl displayed in a ContentControl.